### PR TITLE
Fix responsive navigation on mobile

### DIFF
--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -8,12 +8,13 @@ const pageTitle = title ? `${title} | JNVCKM Alumni Association` : "JNVCKM Alumn
 
 <html>
     <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="/main.css">
         <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🎵</text></svg>">
-        <meta charset="Unicode">
         <link rel="icon" href="/favicon.png" type="image/png">
         <title>{pageTitle}</title>
-        
+
     </head>
     <body>
         <Header />


### PR DESCRIPTION
## Summary
- add a viewport meta tag so modern mobile browsers report their true width
- normalize the layout head metadata to keep the responsive styles engaged

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcba9773ec8327b83ef3d04922ddbc